### PR TITLE
Fix crash when mp3 file have empty 'APIC' frame list

### DIFF
--- a/src/AudioThumbs.cpp
+++ b/src/AudioThumbs.cpp
@@ -75,13 +75,14 @@ bool ATCreator::create ( const QString &path, int /*w*/, int /*h*/, QImage &img 
         TagLib::MPEG::File mp3File(path.toUtf8());
         TagLib::ID3v2::Tag *mp3Tag = mp3File.ID3v2Tag();
         TagLib::ID3v2::FrameList fList = mp3Tag->frameList("APIC");
-        TagLib::ID3v2::AttachedPictureFrame *pic;
-        pic = static_cast<TagLib::ID3v2::AttachedPictureFrame *>(fList.front());
-        if (!pic->picture().isEmpty()) {
-            img.loadFromData((const uchar *) pic->picture().data(),pic->picture().size());
-            bRet = true;
+        if (!fList.isEmpty()) {
+            TagLib::ID3v2::AttachedPictureFrame *pic;
+            pic = static_cast<TagLib::ID3v2::AttachedPictureFrame *>(fList.front());
+            if (!pic->picture().isEmpty()) {
+                img.loadFromData((const uchar *) pic->picture().data(),pic->picture().size());
+                bRet = true;
+            }
         }
-
     } else if (type.name() == "audio/flac" || type.name() == "audio/x-flac") {
         TagLib::FLAC::File ff(path.toUtf8());
         TagLib::List<TagLib::FLAC::Picture *> coverList;


### PR DESCRIPTION
Currently for some mp3 files which have empty 'APIC' frame list it crashes with

```
#0  0x00007f70e2467a11 in TagLib::ID3v2::AttachedPictureFrame::picture() const () from /usr/lib/libtag.so.1
#1  0x00007f70e271925b in ATCreator::create (this=<optimized out>, path=..., img=...)
    at /mnt/AUR/audiothumbs-frameworks-git/src/audiothumbs-frameworks/src/AudioThumbs.cpp:80
#2  0x00007f70f1cc99a3 in ThumbnailProtocol::get(QUrl const&) () from /usr/lib/qt/plugins/kf5/kio/thumbnail.so
#3  0x00007f70fa5953b6 in KIO::SlaveBase::dispatch(int, QByteArray const&) () from /usr/lib/libKF5KIOCore.so.5
#4  0x00007f70fa593b76 in KIO::SlaveBase::dispatchLoop() () from /usr/lib/libKF5KIOCore.so.5
#5  0x00007f70f1cc58fd in kdemain () from /usr/lib/qt/plugins/kf5/kio/thumbnail.so
#6  0x00000000004083b2 in launch(int, char const*, char const*, char const*, int, char const*, bool, char const*, bool, char const*) ()
#7  0x0000000000409c4e in handle_launcher_request(int, char const*) [clone .isra.24] ()
#8  0x000000000040a162 in handle_requests(int) ()
#9  0x0000000000404ec3 in main ()
```

this PR fixes that by checking for this case if it's empty :)
